### PR TITLE
Expand coverage for EdisonLabs\MergeYaml\Plugin

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -62,4 +62,15 @@ class Plugin implements PluginInterface, EventSubscriberInterface, Capable
     {
         $this->pluginHandler->createMergeFiles();
     }
+
+    /**
+     * Gets the plugin handler.
+     *
+     * @return \EdisonLabs\MergeYaml\PluginHandler
+     *   The MergeYaml plugin handler.
+     */
+    public function getPluginHandler()
+    {
+        return $this->pluginHandler;
+    }
 }


### PR DESCRIPTION
### Description
Adds test coverage for `EdisonLabs\MergeYaml\Plugin::activate()` and `EdisonLabs\MergeYaml\Plugin::postCmd()`
